### PR TITLE
Add append and prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ To use library with ES6 modules make sure that you specify `"type": "module"` in
 | aggregate          | No      | [Sync](tests/unittests/tests/Aggregate.ts)
 | all                | Yes     | [Sync](tests/unittests/tests/All.ts), [Async](tests/unittests/tests/AllAsync.ts)
 | any                | Yes     | [Sync](tests/unittests/tests/Any.ts), [Async](tests/unittests/tests/AnyAsync.ts)
+| append             | No      | [Sync](tests/unittests/tests/Append.ts)
 | average            | Yes     | [Sync](tests/unittests/tests/Average.ts), [Async](tests/unittests/tests/AverageAsync.ts)
 | chunk              | No      | [Sync](tests/unittests/tests/Chunk.ts)
 | concatenate        | No      | [Sync](tests/unittests/tests/Concatenate.ts) | Equivalent to `.Concat` but renamed to avoid conflict with JS
@@ -140,6 +141,7 @@ To use library with ES6 modules make sure that you specify `"type": "module"` in
 | orderBy            | Yes     | [Sync](tests/unittests/tests/OrderBy.ts), [Async](tests/unittests/tests/OrderByAsync.ts)
 | orderByDescending  | Yes     | [Sync](tests/unittests/tests/OrderByDescending.ts), [Async](tests/unittests/tests/OrderByDescendingAsync.ts)
 | partition          | Yes     | [Sync](tests/unittests/tests/Partition.ts), [Async](tests/unittests/tests/PartitionAsync.ts)
+| prepend            | No      | [Sync](tests/unittests/tests/Prepend.ts)
 | reverse            | No      | [Sync](tests/unittests/tests/Reverse.ts)
 | select             | Yes     | [Sync](tests/unittests/tests/Select.ts), [Async](tests/unittests/tests/SelectAsync.ts)
 | selectMany         | Yes     | [Sync](tests/unittests/tests/SelectMany.ts), [Async](tests/unittests/tests/SelectManyAsync.ts)

--- a/examples/misc.ts
+++ b/examples/misc.ts
@@ -27,6 +27,9 @@ declare global {
 [1, 2].all((x) => x < 3); // true
 [1, 2].all((x) => x < 2); // false
 
+// APPEND
+[1, 2].append(3); // [1, 2, 3]
+
 // ANY
 [0].any(); // true
 [true].any((x) => !x); // false
@@ -108,6 +111,9 @@ const groupByBreed = cats.groupBy((cat) => cat.breed);
 
 // ORDERBY
 [3, 4, 7, 0, 1].orderBy((x) => x); // [0, 1, 3, 4, 7]
+
+// PREPEND
+[1, 2].prepend(3); // [3, 1, 2]
 
 // REVERSE
 [1, 2, 3].reverse(); // [3, 2, 1]

--- a/src/initializer/bindLinq.ts
+++ b/src/initializer/bindLinq.ts
@@ -5,6 +5,7 @@ import { all } from "./../sync/_private/all"
 import { allAsync } from "./../sync/_private/allAsync"
 import { any } from "./../sync/_private/any"
 import { anyAsync } from "./../sync/_private/anyAsync"
+import { append } from "../sync/_private/append"
 import { asAsync } from "./../sync/_private/asAsync"
 import { asParallel } from "./../sync/_private/asParallel"
 import { average } from "./../sync/_private/average"
@@ -51,6 +52,7 @@ import { orderByDescending } from "./../sync/_private/orderByDescending"
 import { orderByDescendingAsync } from "./../sync/_private/orderByDescendingAsync"
 import { partition } from "./../sync/_private/partition"
 import { partitionAsync } from "./../sync/_private/partitionAsync"
+import { prepend } from "../sync/_private/prepend"
 import { reverse } from "./../sync/_private/reverse"
 import { select } from "./../sync/_private/select"
 import { selectAsync } from "./../sync/_private/selectAsync"
@@ -110,6 +112,7 @@ export const bindLinq = <T, Y extends Iterable<T>>(object: IPrototype<Y>) => {
     bind(allAsync, "allAsync")
     bind(any, "any")
     bind(anyAsync, "anyAsync")
+    bind(append, "append")
     bind(asAsync, "asAsync")
     bind(asParallel, "asParallel")
     bind(average, "average")
@@ -154,6 +157,7 @@ export const bindLinq = <T, Y extends Iterable<T>>(object: IPrototype<Y>) => {
     bind(orderByAsync, "orderByAsync")
     bind(orderByDescending, "orderByDescending")
     bind(orderByDescendingAsync, "orderByDescendingAsync")
+    bind(prepend, "prepend")
     bind(reverse, "reverse")
     bind(select, "select")
     bind(selectAsync, "selectAsync")

--- a/src/sync/_private/append.ts
+++ b/src/sync/_private/append.ts
@@ -1,0 +1,11 @@
+import { IEnumerable } from "../../types"
+import { BasicEnumerable } from "../BasicEnumerable"
+
+export const append = <TSource>(source: Iterable<TSource>, element: TSource): IEnumerable<TSource> => {
+    function* iterator() {
+        yield* source
+        yield element
+    }
+
+    return new BasicEnumerable(iterator)
+}

--- a/src/sync/_private/prepend.ts
+++ b/src/sync/_private/prepend.ts
@@ -1,0 +1,11 @@
+import { IEnumerable } from "../../types"
+import { BasicEnumerable } from "../BasicEnumerable"
+
+export const prepend = <TSource>(source: Iterable<TSource>, element: TSource): IEnumerable<TSource> => {
+    function* iterator() {
+        yield element
+        yield* source
+    }
+
+    return new BasicEnumerable(iterator)
+}

--- a/src/types/IEnumerable.ts
+++ b/src/types/IEnumerable.ts
@@ -72,6 +72,12 @@ export interface IEnumerable<TSource> extends Iterable<TSource> {
      */
     anyAsync(predicate: (x: TSource) => Promise<boolean>): Promise<boolean>
     /**
+     * Appends a value to the end of the sequence.
+     * @param element The value to append to the sequence.
+     * @returns An IEnumerable<T> that ends with the specified element.
+     */
+    append(element: TSource): IEnumerable<TSource>
+    /**
      * Converts the iterable to an @see {IAsyncEnumerable}
      * @returns An IAsyncEnumerable<T>
      */
@@ -495,6 +501,12 @@ export interface IEnumerable<TSource> extends Iterable<TSource> {
      * @returns [values that pass, values that fail]
      */
     partitionAsync(predicate: (x: TSource) => Promise<boolean>): Promise<[pass: TSource[], fail: TSource[]]>
+    /**
+     * Adds a value to the beginning of the sequence.
+     * @param element The value to prepend to the sequence.
+     * @returns An IEnumerable<T> that begins with the specified element.
+     */
+    prepend(element: TSource): IEnumerable<TSource>
     /**
      * Inverts the order of the elements in a sequence.
      * @returns A sequence whose elements correspond to those of the input sequence in reverse order.

--- a/tests/unittests/tests/Append.ts
+++ b/tests/unittests/tests/Append.ts
@@ -1,0 +1,13 @@
+import { itEnumerable } from "../TestHelpers";
+
+describe("Append", () => {
+    itEnumerable<number>("Empty", (asEnumerable) => {
+        const appendArray = asEnumerable([]).append(1).toArray()
+        expect(appendArray).toEqual([1])
+    })
+
+    itEnumerable<number>("Not Empty", (asEnumerable) => {
+        const appendArray = asEnumerable([2, 3]).append(1).toArray()
+        expect(appendArray).toEqual([2, 3, 1])
+    })
+})

--- a/tests/unittests/tests/Prepend.ts
+++ b/tests/unittests/tests/Prepend.ts
@@ -1,0 +1,13 @@
+import { itEnumerable } from "../TestHelpers";
+
+describe("Prepend", () => {
+    itEnumerable<number>("Empty", (asEnumerable) => {
+        const appendArray = asEnumerable([]).prepend(1).toArray()
+        expect(appendArray).toEqual([1])
+    })
+
+    itEnumerable<number>("Not Empty", (asEnumerable) => {
+        const appendArray = asEnumerable([2, 3]).prepend(1).toArray()
+        expect(appendArray).toEqual([1, 2, 3])
+    })
+})

--- a/tests/unittests/tests/examples/MiscExamples.ts
+++ b/tests/unittests/tests/examples/MiscExamples.ts
@@ -37,6 +37,9 @@ describe("miscExamples", () => {
         [0].any(); // true
         [true].any((x) => !x); // false
 
+        // APPEND
+        [1, 2].append(3); // [1, 2, 3]
+
         // CONCAT
         [1, 2].concatenate([2, 3]); // [1, 2, 2, 3]
 
@@ -114,6 +117,9 @@ describe("miscExamples", () => {
 
         // ORDERBY
         [3, 4, 7, 0, 1].orderBy((x) => x); // [0, 1, 3, 4, 7]
+
+        // PREPEND
+        [1, 2].prepend(3); // [3, 1, 2]
 
         // REVERSE
         [1, 2, 3].reverse(); // [3, 2, 1]


### PR DESCRIPTION
Add implementations of [`Append(T)`](https://learn.microsoft.com/dotnet/api/system.linq.enumerable.append) and [`Prepend(T)`](https://learn.microsoft.com/dotnet/api/system.linq.enumerable.prepend).
